### PR TITLE
Fixes in the React Markdown Code styles

### DIFF
--- a/app/features/chat/components/MarkdownRender.tsx
+++ b/app/features/chat/components/MarkdownRender.tsx
@@ -19,19 +19,26 @@ export const MarkdownRenderer = memo(({ content }: { content: string }) => {
       components={{
         code({ inline, className, children }: CodeProps) {
           const match = /language-(\w+)/.exec(className || "");
+          if(inline) {
+            return (
+              <code className="bg-red-500 px-1 rounded max-w-2xl overflow-auto">
+                {children}
+              </code>
+            )
+          }
 
-          return !inline && match ? (
+          return (
             <SyntaxHighlighter
               style={oneDark}
-              language={match[1]}
+              language={match && match[1] || "bash"}
               PreTag="div"
+              customStyle={{
+                overflowX: "auto",
+                maxWidth: "100%"
+              }}
             >
               {String(children).replace(/\n$/, "")}
             </SyntaxHighlighter>
-          ) : (
-            <code className="bg-gray-200 px-1 rounded">
-              {children}
-            </code>
           );
         },
       }}

--- a/app/features/chat/components/MarkdownRender.tsx
+++ b/app/features/chat/components/MarkdownRender.tsx
@@ -30,7 +30,7 @@ export const MarkdownRenderer = memo(({ content }: { content: string }) => {
               PreTag="div"
               wrapLongLines
               customStyle={{
-                overflowX: "hidden",
+                overflowX: "auto",
                 whiteSpace: "pre-wrap",
                 wordBreak: "break-word",
                 maxWidth: "100%",

--- a/app/features/chat/components/MarkdownRender.tsx
+++ b/app/features/chat/components/MarkdownRender.tsx
@@ -6,22 +6,18 @@ import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { oneDark } from "react-syntax-highlighter/dist/esm/styles/prism";
 import remarkGfm from "remark-gfm";
 
-type CodeProps = {
- inline?:boolean,
- className?: string,
- children?:React.ReactNode
-}
-
 export const MarkdownRenderer = memo(({ content }: { content: string }) => {
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
       components={{
-        code({ inline, className, children }: CodeProps) {
+        code(props) {
+          const { children, className, node} = props
           const match = /language-(\w+)/.exec(className || "");
-          if(inline) {
+          const isInline = node?.position?.start.line === node?.position?.end.line
+          if(isInline && !match) {
             return (
-              <code className="bg-red-500 px-1 rounded max-w-2xl overflow-auto">
+              <code className="inline bg-zinc-700 text-zinc-100 px-1 rounded">
                 {children}
               </code>
             )
@@ -30,11 +26,14 @@ export const MarkdownRenderer = memo(({ content }: { content: string }) => {
           return (
             <SyntaxHighlighter
               style={oneDark}
-              language={match && match[1] || "bash"}
+              language={match && match[1] || "text"}
               PreTag="div"
+              wrapLongLines
               customStyle={{
-                overflowX: "auto",
-                maxWidth: "100%"
+                overflowX: "hidden",
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
+                maxWidth: "100%",
               }}
             >
               {String(children).replace(/\n$/, "")}

--- a/app/features/chat/components/MetricsCard.tsx
+++ b/app/features/chat/components/MetricsCard.tsx
@@ -21,24 +21,24 @@ const MetricsCard = ({totalToken, promptToken, completionToken, totalTime=0, tok
             <div className="flex items-center justify-between"><div className="font-bold">Usage & Metrics</div>{getBadge(firstChunk, streaming, firstChunkPercent, streamingPercent)}</div>
             <div className="flex flex-col my-2">
                 <span className="font-bold">Tokens</span>
-                <span className="text-sm text-black">{totalToken} Total</span>
+                <span className="text-sm text-black dark:text-zinc-100">{totalToken} Total</span>
                 <div className="flex gap-2 items-center">
-                    <div className="text-sm "><span className="text-black">{promptToken}</span> prompt</div>
+                    <div className="text-sm "><span className="text-black dark:text-zinc-100">{promptToken}</span> prompt</div>
                     •
-                    <div className="text-sm "><span className="text-black">{completionToken}</span> completion</div>
+                    <div className="text-sm "><span className="text-black dark:text-zinc-100">{completionToken}</span> completion</div>
                 </div>
             </div>
             <div className="flex flex-col my-2">
                 <span className="font-bold">Performance</span>
-                <div className="text-sm">Total Time: <span className="text-black">{totalTime.toFixed(0)} ms</span></div>
-                <div className="text-sm">Token Speed: <span className="text-black">{tokenSpeed.toFixed(0)} tok/s</span></div>
+                <div className="text-sm">Total Time: <span className="text-black dark:text-zinc-100">{totalTime.toFixed(0)} ms</span></div>
+                <div className="text-sm">Token Speed: <span className="text-black dark:text-zinc-100">{tokenSpeed.toFixed(0)} tok/s</span></div>
             </div>
             <div className="flex flex-col my-2">
                 <span className="font-bold">Response Timeline</span>
                 <div className="text-slate-500 text-xs">{getInsight(firstChunkPercent, streamingPercent)}</div>
                 <MetricsBar metrics={createMetricVisual(firstChunkPercent, streamingPercent)} />
-                <div className="flex gap-2 items-center text-sm"><div className="flex items-center gap-2 min-w-36"><div className="w-2 h-2 bg-slate-500"/> Time to First Token:</div> <span className="text-black min-w-20">{firstChunk.toFixed(0)} ms</span> ({firstChunkPercent.toFixed(0)}%)</div>
-                <div className="flex gap-2 items-center text-sm"><div className="flex items-center gap-2 min-w-36"><div className="w-2 h-2 bg-cyan-500"/> Streaming:</div> <span className="text-black min-w-20">{streaming.toFixed(0)} ms</span> ({streamingPercent.toFixed(0)}%)</div>
+                <div className="flex gap-2 items-center text-sm"><div className="flex items-center gap-2 min-w-36"><div className="w-2 h-2 bg-slate-500"/> Time to First Token:</div> <span className="text-black dark:text-zinc-100  min-w-20">{firstChunk.toFixed(0)} ms</span> ({firstChunkPercent.toFixed(0)}%)</div>
+                <div className="flex gap-2 items-center text-sm"><div className="flex items-center gap-2 min-w-36"><div className="w-2 h-2 bg-cyan-500"/> Streaming:</div> <span className="text-black dark:text-zinc-100 min-w-20">{streaming.toFixed(0)} ms</span> ({streamingPercent.toFixed(0)}%)</div>
             </div>
         </div>
     )


### PR DESCRIPTION
- Fixed the horizontal scroll for the code styles in React MD
- Fixed the differentiation between inline code(eg: `code`) and code block(eg:
```typescript
 const a = "23"
```
).
- Fixed the UX in the metrics card for dark theme.

### Screenshots
<img width="1919" height="946" alt="image" src="https://github.com/user-attachments/assets/326cf748-7024-44e1-bfb4-7785742699a2" />

<img width="1919" height="943" alt="image" src="https://github.com/user-attachments/assets/b09ebe2c-91f1-4e94-8bd4-79197f18a5ef" />

<img width="1919" height="948" alt="image" src="https://github.com/user-attachments/assets/82cde164-0d73-4b58-8c81-8cc0ebe73325" />
